### PR TITLE
Renaming test file

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,10 +8,10 @@ class BasicTestCase(unittest.TestCase):
         r = requests.get('http://127.0.0.1:5000/')
         self.assertEqual(r.status_code,200)
 
-    
+
     def test_person_endpoint(self):
-        r = requests.get('http://127.0.0.1:5000/')
+        r = requests.get('http://127.0.0.1:5000/persons')
         self.assertEqual(r.status_code,200)
         json_dict = r.json()
-        self.assertEqual(json_dict['Status'],'Success')
-        self.assertIsNotNone(json_dict["Data"])
+        self.assertEqual(json_dict['success'],True)
+        self.assertIsNotNone(json_dict["result"])


### PR DESCRIPTION
After dealing with `Ran 0 test in 0.000s` for about an hour I came across this [bug report](https://bugs.python.org/issue11298).

When I renamed `test/basic_test.py` to `test/test_basic.py` the test started running correctly.