### PR TITLE
Create Model_id_recursion.py

### DIFF
--- a/api/models/model_class_possibilities/Model_id_recursion.py
+++ b/api/models/model_class_possibilities/Model_id_recursion.py
@@ -1,5 +1,8 @@
 # for more detail, see class Model in :
 # https://github.com/pallets/flask-sqlalchemy/blob/master/flask_sqlalchemy/model.py
+from typing import Any, List, Type
+
+
 class MyModel(object):
     query_class = None  # flask_alchemy attribute
     query = None  # flask_alchemy attribute
@@ -8,19 +11,19 @@ class MyModel(object):
     DONOTSEND = []
     _jsonified = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<{}>'.format(self.__class__.__name__)
 
-    def to_dict_recursive(self):
+    def to_dict_recursive(self) -> dict:
         return self._to_dict_recursive(list_objects_id_passed_through=[id(self)])
 
-    def _to_dict_recursive(self, list_objects_id_passed_through):
+    def _to_dict_recursive(self, list_objects_id_passed_through: List[int]) -> dict:
         # functions :
         # anti_circular_recursion : check if we've already called the object
         #                               if not do the recursion
         # type_shunt_recursive : select the actions for each type of attr
 
-        def anti_circular_recursion(obj):
+        def anti_circular_recursion(obj: Type[MyModel]) -> any:
             if id(obj) in list_objects_id_passed_through:
                 return str(obj)
                 # others possibilities
@@ -31,7 +34,7 @@ class MyModel(object):
                 return obj._to_dict_recursive(list_objects_id_passed_through)
 
         ##### what about dict which contains object(s) ? Is it possible in SQLAlchemy ?
-        def type_shunt_recursive(attribute):
+        def type_shunt_recursive(attribute: Any) -> Any:
             # model
             if issubclass(type(attribute), MyModel):
                 return anti_circular_recursion(attribute)

--- a/api/models/model_class_possibilities/Model_id_recursion.py
+++ b/api/models/model_class_possibilities/Model_id_recursion.py
@@ -1,0 +1,57 @@
+# for more detail, see class Model in :
+# https://github.com/pallets/flask-sqlalchemy/blob/master/flask_sqlalchemy/model.py
+class MyModel(object):
+    query_class = None  # flask_alchemy attribute
+    query = None  # flask_alchemy attribute
+
+    DONOTSEND_MODEL = {'_sa_instance_state'}
+    DONOTSEND = []
+    _jsonified = None
+
+    def __repr__(self):
+        return '<{}>'.format(self.__class__.__name__)
+
+    def to_dict_recursive(self):
+        return self._to_dict_recursive(list_objects_id_passed_through=[id(self)])
+
+    def _to_dict_recursive(self, list_objects_id_passed_through):
+        # functions :
+        # anti_circular_recursion : check if we've already called the object
+        #                               if not do the recursion
+        # type_shunt_recursive : select the actions for each type of attr
+
+        def anti_circular_recursion(obj):
+            if id(obj) in list_objects_id_passed_through:
+                return str(obj)
+                # others possibilities
+                # return str(obj).join(' ').join(str(obj.id))
+                # return obj.id
+            else:
+                list_objects_id_passed_through.append(id(obj))
+                return obj._to_dict_recursive(list_objects_id_passed_through)
+
+        ##### what about dict which contains object(s) ? Is it possible in SQLAlchemy ?
+        def type_shunt_recursive(attribute):
+            # model
+            if issubclass(type(attribute), MyModel):
+                return anti_circular_recursion(attribute)
+            # recursive iteration of the list in case of the list is a relationship
+            elif isinstance(attribute, list):
+                values = []
+                for item in attribute:
+                    values.append(type_shunt_recursive(item))
+                return values
+            # attribute is not an instance of relationship (int, str..)
+            else:
+                return attribute
+
+        result = {}
+
+        # __mapper__ is equivalent to db.inspect(self)
+        # but db (database) is not created yet cause we send this model to the constructor
+        for key in self.__mapper__.attrs.keys():
+            if key not in self.DONOTSEND:
+                attr = getattr(self, key)
+                result[key] = type_shunt_recursive(attr)
+
+        return result


### PR DESCRIPTION
I have achieved the perfect recursion without using depth. We should using it at the creation of the database : 
`db = SQLAlchemy(app, model_class=MyModel)`
Cause with we use a mixin and we forgot to use it, if an a class with mixin has a relationship with one without mixin it will create a complicate bug.
And this because we do this test : `if issubclass(type(attribute), MyModel)`
so if MyModel is a mixin, we might skip the recursive and send back a dict with an object inside !