### PR TITLE
fix: POST /persons is now returning data from DB

### DIFF
--- a/api/views/main.py
+++ b/api/views/main.py
@@ -47,5 +47,5 @@ def create_person():
     db.session.add_all([new_person, email])
     db.session.commit()
     return create_response(
-        message=f"Successfully created person {new_person.name} with id: {new_person._id}"
+        message=f"Successfully created person {new_person.name} with id: {new_person.id}"
     )


### PR DESCRIPTION
Hello, first things first: thank you for creating this boilerplate - it actually saves a lot of my time.

I suppose that instead of `new_person._id`, your code should be referring to the `.id` property, without the underscore. I consider this is essential because some developers may get confused with this example.

If you are running this locally, the endpoint is 
```
POST http://localhost:5000/persons
Content-Type: application/json

{
    "name": "Joe",
    "email": "joe@example.com"
}
```


I've tested this and it works:
![image](https://user-images.githubusercontent.com/40323691/103818798-da5d3480-5071-11eb-956b-484483203f21.png)
